### PR TITLE
Updated to 1.3.2 and fixed bug with PUT/PATCH being replaced with POST

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+### Context
+
+
+### What has been done
+
+-
+-
+
+### How to test
+
+-
+-
+
+### Todo
+
+- [ ]
+- [ ]
+
+### Notes
+
+-
+-
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 coverage/*
 notes.md
 tests/fixtures/cassette*
+/.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,23 @@
+<?php
+$config = Symfony\CS\Config\Config::create()
+    ->level('psr2')
+    ->fixers(
+        array(
+            'single_blank_line_before_namespace',
+            'concat_with_spaces',
+            'single_quote',
+            'braces',
+        )
+    )
+    ->finder(
+        Symfony\CS\Finder\DefaultFinder::create()
+            ->exclude('vendor')
+            ->exclude('docs')
+            ->in(__DIR__)
+    )
+    ->setUsingCache(true);
+
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+$config->setDir($cacheDir);
+
+return $config;

--- a/.php_cs
+++ b/.php_cs
@@ -1,6 +1,6 @@
 <?php
 $config = Symfony\CS\Config\Config::create()
-    ->level('psr2')
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ->fixers(
         array(
             'single_blank_line_before_namespace',
@@ -10,7 +10,7 @@ $config = Symfony\CS\Config\Config::create()
         )
     )
     ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
+        Symfony\CS\Finder::create()
             ->exclude('vendor')
             ->exclude('docs')
             ->in(__DIR__)

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 
 script:
   - $PHPUNIT_BIN --coverage-clover=coverage.clover
-  - $PHPCS_FIXER_BIN fix --config-file=.php_cs --dry-run --diff $TRAVIS_BUILD_DIR
+  - test $TEST_DIR = "." && $PHPCS_FIXER_BIN fix --config-file=.php_cs --dry-run --diff $TRAVIS_BUILD_DIR || echo "Continue without php-cs-fixer"
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,13 @@ before_install:
 install:
   - composer update --prefer-source -o $COMPOSER_FLAGS
   - PHPUNIT_BIN=$(pwd)/vendor/bin/phpunit
+  - PHPCS_FIXER_BIN=$(pwd)/vendor/bin/php-cs-fixer
   - cd ${TEST_DIR}
   - composer update --prefer-source -o $COMPOSER_FLAGS
 
 script:
   - $PHPUNIT_BIN --coverage-clover=coverage.clover
+  - $PHPCS_FIXER_BIN fix --dry-run --diff $TRAVIS_BUILD_DIR
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
       php: 7.0
     - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
       php: 7.0
+    - env: TEST_DIR=.
+      php: 7.1
+    - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+      php: 7.1
     - env: TEST_DIR=tests/integration/guzzle/3
       php: 5.6
     - env: TEST_DIR=tests/integration/guzzle/4

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 
 script:
   - $PHPUNIT_BIN --coverage-clover=coverage.clover
-  - $PHPCS_FIXER_BIN fix --dry-run --diff $TRAVIS_BUILD_DIR
+  - $PHPCS_FIXER_BIN fix --config-file=.php_cs --dry-run --diff $TRAVIS_BUILD_DIR
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In order to run all tests you need to get development dependencies using compose
 
 ``` php
 composer install
-./vendor/bin/phpunit
+composer test
 ```
 
 ## Changelog

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "phpunit/phpunit": "^4.8|^5.0",
         "sebastian/version": "^1.0.3|^2.0",
         "mikey179/vfsStream": "^1.2",
-        "lapistano/proxy-object": "dev-master#d7184a479f502d5a0f96d0bae73566dbb498da8f"
+        "lapistano/proxy-object": "dev-master#d7184a479f502d5a0f96d0bae73566dbb498da8f",
+        "friendsofphp/php-cs-fixer": "^1.12"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "license": "MIT",
     
     "scripts": {
-        "test": "./vendor/bin/phpunit"
+        "test": "./vendor/bin/phpunit",
+        "lint": "./vendor/bin/php-cs-fixer fix --verbose --diff --dry-run --config-file=.php_cs",
+        "fix": "./vendor/bin/php-cs-fixer fix --verbose --diff --config-file=.php_cs"
     },
     
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,11 @@
     "name": "php-vcr/php-vcr",
     "description": "Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.",
     "license": "MIT",
-
+    
+    "scripts": {
+        "test": "./vendor/bin/phpunit"
+    },
+    
     "authors": [
         {
             "name": "Adrian Philipp",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "56981a72b3bd6103b3ee728e65ce06a8",
-    "content-hash": "d1e75f5a4a3ac2561d04ce03e1cf0e56",
+    "hash": "d3d4cbb9a4eba4ceb63560b256310284",
+    "content-hash": "1f3790cdac8e818a575f21f982a94880",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -64,16 +64,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5"
+                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
-                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
+                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
                 "shasum": ""
             },
             "require": {
@@ -120,20 +120,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-19 10:45:57"
+            "time": "2016-10-13 06:28:43"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3"
+                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/368b9738d4033c8b93454cb0dbd45d305135a6d3",
-                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
                 "shasum": ""
             },
             "require": {
@@ -169,7 +169,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-25 08:27:07"
+            "time": "2016-10-24 18:41:13"
         }
     ],
     "packages-dev": [
@@ -226,6 +226,64 @@
                 "instantiate"
             ],
             "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v1.12.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "78a820c16d13f593303511461eefa939502fb2de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/78a820c16d13f593303511461eefa939502fb2de",
+                "reference": "78a820c16d13f593303511461eefa939502fb2de",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^5.3.6 || >=7.0 <7.2",
+                "sebastian/diff": "^1.1",
+                "symfony/console": "^2.3 || ^3.0",
+                "symfony/event-dispatcher": "^2.1 || ^3.0",
+                "symfony/filesystem": "^2.1 || ^3.0",
+                "symfony/finder": "^2.1 || ^3.0",
+                "symfony/process": "^2.3 || ^3.0",
+                "symfony/stopwatch": "^2.5 || ^3.0"
+            },
+            "conflict": {
+                "hhvm": "<3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\CS\\": "Symfony/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2016-10-30 12:07:10"
         },
         {
             "name": "lapistano/proxy-object",
@@ -955,6 +1013,53 @@
             "time": "2016-10-09 07:01:45"
         },
         {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10 12:19:37"
+        },
+        {
             "name": "sebastian/code-unit-reverse-lookup",
             "version": "1.0.0",
             "source": {
@@ -1466,6 +1571,379 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-02-04 12:56:52"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c99da1119ae61e15de0e4829196b9fba6f73d065",
+                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/debug": "~2.8|~3.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-10-06 01:44:51"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v3.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 11:02:40"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v3.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "0565b61bf098cb4dc09f4f103f033138ae4f42c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0565b61bf098cb4dc09f4f103f033138ae4f42c6",
+                "reference": "0565b61bf098cb4dc09f4f103f033138ae4f42c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-10-18 04:30:12"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
+                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-28 00:11:12"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-05-18 14:26:46"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v3.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/66de154ae86b1a07001da9fbffd620206e4faf94",
+                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-29 14:13:09"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v3.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/bb42806b12c5f89db4ebf64af6741afe6d8457e1",
+                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
         },
         {
             "name": "webmozart/assert",

--- a/src/VCR/Cassette.php
+++ b/src/VCR/Cassette.php
@@ -40,7 +40,7 @@ class Cassette
      */
     public function __construct($name, Configuration $config, Storage $storage)
     {
-        Assertion::string($name, "Cassette name must be a string, " . \gettype($name) . " given.");
+        Assertion::string($name, 'Cassette name must be a string, ' . \gettype($name) . ' given.');
 
         $this->name = $name;
         $this->config = $config;

--- a/src/VCR/CodeTransform/SoapCodeTransform.php
+++ b/src/VCR/CodeTransform/SoapCodeTransform.php
@@ -16,10 +16,10 @@ class SoapCodeTransform extends AbstractCodeTransform
         '@extends\s+\\\?SoapClient@i',
     );
 
-  /**
-   * @inheritdoc
-   */
-  protected function transformCode($code)
+    /**
+     * @inheritdoc
+     */
+    protected function transformCode($code)
     {
         return preg_replace(self::$patterns, self::$replacements, $code);
     }

--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -287,7 +287,7 @@ class Configuration
      * Enables specified RequestMatchers by its name.
      *
      * @param array $matchers List of RequestMatcher names to enable.
-     * 
+     *
      * @return Configuration
      *
      * @throws \InvalidArgumentException If a specified request matcher does not exist.
@@ -381,7 +381,7 @@ class Configuration
         Assertion::directory(
             $cassettePath,
             "Cassette path '{$cassettePath}' is not a directory. Please either "
-            . "create it or set a different cassette path using "
+            . 'create it or set a different cassette path using '
             . "\\VCR\\VCR::configure()->setCassettePath('directory')."
         );
     }

--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -46,9 +46,9 @@ class CurlHook implements LibraryHook
     protected static $multiHandles = array();
 
     /**
-     * @var resource Last active curl_multi_exec() handle.
+     * @var array Last active curl_multi_exec() handles.
      */
-    protected static $multiExecLastCh;
+    protected static $multiExecLastChs = array();
 
     /**
      * @var AbstractCodeTransform
@@ -253,7 +253,7 @@ class CurlHook implements LibraryHook
         if (isset(self::$multiHandles[(int) $multiHandle])) {
             foreach (self::$multiHandles[(int) $multiHandle] as $curlHandle) {
                 if (!isset(self::$responses[(int) $curlHandle])) {
-                    self::$multiExecLastCh = $curlHandle;
+                    self::$multiExecLastChs[] = $curlHandle;
                     self::curlExec($curlHandle);
                 }
             }
@@ -271,13 +271,12 @@ class CurlHook implements LibraryHook
      */
     public static function curlMultiInfoRead()
     {
-        if (self::$multiExecLastCh) {
+        if (!empty(self::$multiExecLastChs)) {
             $info = array(
                 'msg' => CURLMSG_DONE,
-                'handle' => self::$multiExecLastCh,
+                'handle' => array_pop(self::$multiExecLastChs),
                 'result' => CURLE_OK
             );
-            self::$multiExecLastCh = null;
 
             return $info;
         }

--- a/src/VCR/LibraryHooks/SoapHook.php
+++ b/src/VCR/LibraryHooks/SoapHook.php
@@ -77,9 +77,11 @@ class SoapHook implements LibraryHook
         if ($version === SOAP_1_1) {
             $vcrRequest->setHeader('Content-Type', 'text/xml; charset=utf-8;');
             $vcrRequest->setHeader('SOAPAction', $action);
-
         } else { // >= SOAP_1_2
-            $vcrRequest->setHeader('Content-Type', sprintf('application/soap+xml; charset=utf-8; action="%s"', $action));
+            $vcrRequest->setHeader(
+                'Content-Type',
+                sprintf('application/soap+xml; charset=utf-8; action="%s"', $action)
+            );
         }
 
         $vcrRequest->setBody($request);

--- a/src/VCR/LibraryHooks/StreamWrapperHook.php
+++ b/src/VCR/LibraryHooks/StreamWrapperHook.php
@@ -174,7 +174,7 @@ class StreamWrapperHook implements LibraryHook
      * @return array See stat().
      */
 
-    public function url_stat($path,$flags)
+    public function url_stat($path, $flags)
     {
         return array();
     }
@@ -194,23 +194,23 @@ class StreamWrapperHook implements LibraryHook
         switch ($whence) {
             case SEEK_SET:
                 if ($offset < strlen($this->response->getBody()) && $offset >= 0) {
-                     $this->position = $offset;
+                    $this->position = $offset;
 
-                     return true;
+                    return true;
                 }
                 break;
             case SEEK_CUR:
                 if ($offset >= 0) {
-                     $this->position += $offset;
+                    $this->position += $offset;
 
-                     return true;
+                    return true;
                 }
                 break;
             case SEEK_END:
                 if (strlen($this->response->getBody()) + $offset >= 0) {
-                     $this->position = strlen($this->response->getBody()) + $offset;
+                    $this->position = strlen($this->response->getBody()) + $offset;
 
-                     return true;
+                    return true;
                 }
         }
 

--- a/src/VCR/Request.php
+++ b/src/VCR/Request.php
@@ -41,7 +41,7 @@ class Request
      * @param string $url
      * @param array $headers
      */
-    function __construct($method, $url, array $headers = array())
+    public function __construct($method, $url, array $headers = array())
     {
         $this->method = $method;
         $this->headers = $headers;
@@ -200,7 +200,7 @@ class Request
         $host = parse_url($this->getUrl(), PHP_URL_HOST);
 
         if ($port = parse_url($this->getUrl(), PHP_URL_PORT)) {
-          $host .= ':' . $port;
+            $host .= ':' . $port;
         }
 
         return $host;
@@ -234,7 +234,8 @@ class Request
      * @param $key
      * @return mixed
      */
-    public function getCurlOption($key) {
+    public function getCurlOption($key)
+    {
         if (empty($this->curlOptions[$key])) {
             return null;
         }
@@ -334,5 +335,4 @@ class Request
     {
         $this->postFiles[] = $file;
     }
-
 }

--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace VCR;
+
 use VCR\Util\Assertion;
 
 /**
@@ -37,7 +38,7 @@ class Response
      * @param string $body
      * @param array $curlInfo
      */
-    function __construct($status, array $headers = array(), $body = null, array $curlInfo = array())
+    public function __construct($status, array $headers = array(), $body = null, array $curlInfo = array())
     {
         $this->setStatus($status);
         $this->headers = $headers;
@@ -54,8 +55,7 @@ class Response
     {
         $body = $this->getBody();
         // Base64 encode when binary
-        if (
-            strpos($this->getContentType(), 'application/x-gzip') !== false
+        if (strpos($this->getContentType(), 'application/x-gzip') !== false
             || $this->getHeader('Content-Transfer-Encoding') == 'binary'
         ) {
             $body = base64_encode($body);

--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -104,7 +104,8 @@ abstract class AbstractStorage implements Storage
      *
      * @return boolean TRUE if created, FALSE if not
      */
-    public function isNew() {
+    public function isNew()
+    {
         return $this->isNew;
     }
 

--- a/src/VCR/Storage/Json.php
+++ b/src/VCR/Storage/Json.php
@@ -53,8 +53,12 @@ class Json extends AbstractStorage
         $record = '';
 
         while (false !== ($char = fgetc($this->handle))) {
-            if ($char === '{') {++$depth;}
-            if ($char === '}') {--$depth;}
+            if ($char === '{') {
+                ++$depth;
+            }
+            if ($char === '}') {
+                --$depth;
+            }
 
             if (!$isInRecord && $char === '{') {
                 $isInRecord = true;

--- a/src/VCR/Util/Assertion.php
+++ b/src/VCR/Util/Assertion.php
@@ -22,7 +22,7 @@ class Assertion extends BaseAssertion
      */
     public static function isCallable($value, $message = null, $propertyPath = null)
     {
-        if ( ! is_callable($value)) {
+        if (! is_callable($value)) {
             throw new VCRException($message, self::INVALID_CALLABLE, $propertyPath);
         }
     }

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -160,6 +160,7 @@ class CurlHelper
                 } else {
                     $request->setBody($value);
                 }
+                $request->setMethod('POST');
                 break;
             case CURLOPT_HTTPHEADER:
                 foreach ($value as $header) {

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -160,7 +160,6 @@ class CurlHelper
                 } else {
                     $request->setBody($value);
                 }
-                $request->setMethod('POST');
                 break;
             case CURLOPT_HTTPHEADER:
                 foreach ($value as $header) {

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -165,8 +165,8 @@ class CurlHelper
                 foreach ($value as $header) {
                     $headerParts = explode(': ', $header, 2);
                     if (!isset($headerParts[1])) {
-                       $headerParts[0] = rtrim($headerParts[0], ':');
-                       $headerParts[1] = null;
+                        $headerParts[0] = rtrim($headerParts[0], ':');
+                        $headerParts[1] = null;
                     }
                     $request->setHeader($headerParts[0], $headerParts[1]);
                 }
@@ -201,12 +201,12 @@ class CurlHelper
         
         // Guzzle 4 sometimes sets the post body in CURLOPT_POSTFIELDS even if
         // they have already set CURLOPT_READFUNCTION.
-        if ($request->getBody()){
+        if ($request->getBody()) {
             return;
         }
         
         $bodySize = $request->getCurlOption(CURLOPT_INFILESIZE);
-        Assertion::notEmpty($bodySize, "To set a CURLOPT_READFUNCTION, CURLOPT_INFILESIZE must be set.");
+        Assertion::notEmpty($bodySize, 'To set a CURLOPT_READFUNCTION, CURLOPT_INFILESIZE must be set.');
         $body = call_user_func_array($readFunction, array($curlHandle, fopen('php://memory', 'r'), $bodySize));
         $request->setBody($body);
     }

--- a/src/VCR/Util/HttpUtil.php
+++ b/src/VCR/Util/HttpUtil.php
@@ -19,7 +19,7 @@ class HttpUtil
 
         // Collect matching headers into groups
         foreach ($headers as $line) {
-            list ($key, $value) = explode(': ', $line, 2);
+            list($key, $value) = explode(': ', $line, 2);
             if (!isset($headerGroups[$key])) {
                 $headerGroups[$key] = array();
             }
@@ -42,7 +42,11 @@ class HttpUtil
      */
     public static function parseStatus($status)
     {
-        Assertion::startsWith($status, 'HTTP/', "Invalid HTTP status '$status', expected format like: 'HTTP/1.1 200 OK'.");
+        Assertion::startsWith(
+            $status,
+            'HTTP/',
+            "Invalid HTTP status '$status', expected format like: 'HTTP/1.1 200 OK'."
+        );
 
         $part = explode(' ', $status, 3);
 
@@ -78,7 +82,8 @@ class HttpUtil
      * @param string $header
      * @return array
      */
-    public static function parseRawHeader($rawHeader) {
+    public static function parseRawHeader($rawHeader)
+    {
         return explode("\r\n", trim($rawHeader));
     }
 

--- a/src/VCR/Util/SoapClient.php
+++ b/src/VCR/Util/SoapClient.php
@@ -27,9 +27,10 @@ class SoapClient extends \SoapClient
      */
     protected $request;
 
-    public function __construct($wsdl, $options = array()) {
-       $this->options = $options;
-       parent::__construct($wsdl, $options);
+    public function __construct($wsdl, $options = array())
+    {
+        $this->options = $options;
+        parent::__construct($wsdl, $options);
     }
 
     /**

--- a/src/VCR/Util/StreamHelper.php
+++ b/src/VCR/Util/StreamHelper.php
@@ -21,7 +21,8 @@ class StreamHelper
      *
      * @return Request
      */
-    public static function createRequestFromStreamContext($context, $path, Request $existing = null) {
+    public static function createRequestFromStreamContext($context, $path, Request $existing = null)
+    {
         $http = self::getHttpOptionsFromContext($context);
         $request = $existing;
 
@@ -68,7 +69,8 @@ class StreamHelper
      * @see http://php.net/manual/en/context.http.php
      * @return array HTTP options.
      */
-    protected static function getHttpOptionsFromContext($context) {
+    protected static function getHttpOptionsFromContext($context)
+    {
         if (!$context) {
             return array();
         }

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -464,6 +464,7 @@ class StreamProcessor
      */
     public function stream_lock($operation)
     {
+        $operation = ($operation == 0 ? LOCK_EX : $operation);
         return flock($this->resource, $operation);
     }
 

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -161,7 +161,8 @@ class StreamProcessor
      *
      * @param  string  $path       Specifies the URL that was passed to the original function.
      * @param  string  $mode       The mode used to open the file, as detailed for fopen().
-     * @param  integer $options    Holds additional flags set by the streams API. It can hold one or more of the following values OR'd together.
+     * @param  integer $options    Holds additional flags set by the streams API.
+     *                             It can hold one or more of the following values OR'd together.
      * @param  string  $openedPath If the path is opened successfully, and STREAM_USE_PATH is set in options,
      *                             opened_path should be set to the full path of the file/resource that was
      *                             actually opened.
@@ -293,7 +294,7 @@ class StreamProcessor
     {
         $this->restore();
         if ($flags & STREAM_URL_STAT_QUIET) {
-            set_error_handler(function() {
+            set_error_handler(function () {
                 // Use native error handler
                 return false;
             });

--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -464,7 +464,7 @@ class StreamProcessor
      */
     public function stream_lock($operation)
     {
-        $operation = ($operation == 0 ? LOCK_EX : $operation);
+        $operation = ($operation === 0 ? LOCK_EX : $operation);
         return flock($this->resource, $operation);
     }
 

--- a/src/VCR/Videorecorder.php
+++ b/src/VCR/Videorecorder.php
@@ -204,14 +204,15 @@ class Videorecorder
      *
      * @return Response                Response for the intercepted request.
      * @throws \BadMethodCallException If there was no cassette inserted.
-     * @throws \LogicException         If the mode is set to none or once and the cassette did not have a matching response.
+     * @throws \LogicException         If the mode is set to none or once and
+     *                                 the cassette did not have a matching response.
      */
     public function handleRequest(Request $request)
     {
         if ($this->cassette === null) {
             throw new \BadMethodCallException(
-                "Invalid http request. No cassette inserted. "
-                . "Please make sure to insert a cassette in your unit test using "
+                'Invalid http request. No cassette inserted. '
+                . 'Please make sure to insert a cassette in your unit test using '
                 . "VCR::insertCassette('name');"
             );
         }
@@ -228,13 +229,20 @@ class Videorecorder
             return $response;
         }
 
-        if (VCR::MODE_NONE === $this->config->getMode() || VCR::MODE_ONCE === $this->config->getMode() && $this->cassette->isNew() === false) {
+        if (VCR::MODE_NONE === $this->config->getMode()
+            || VCR::MODE_ONCE === $this->config->getMode()
+            && $this->cassette->isNew() === false
+        ) {
             throw new \LogicException(
-                "The request does not match a previously recorded request and the 'mode' is set to '{$this->config->getMode()}'. "
-                . "If you want to send the request anyway, make sure your 'mode' is set to 'new_episodes'. "
-                . "Please see http://php-vcr.github.io/documentation/configuration/#record-modes."
-                ."\nCassette: ".$this->cassette->getName()
-                ."\nRequest: ".print_r($request->toArray(), true)
+                sprintf(
+                    "The request does not match a previously recorded request and the 'mode' is set to '%s'. "
+                    . "If you want to send the request anyway, make sure your 'mode' is set to 'new_episodes'. "
+                    . 'Please see http://php-vcr.github.io/documentation/configuration/#record-modes.'
+                    . "\nCassette: %s \n Request: %s",
+                    $this->config->getMode(),
+                    $this->cassette->getName(),
+                    print_r($request->toArray(), true)
+                )
             );
         }
 

--- a/tests/VCR/CodeTransform/AbstractCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/AbstractCodeTransformTest.php
@@ -4,7 +4,6 @@ namespace VCR\CodeTransform;
 
 class AbstractCodeTransformTest extends \PHPUnit_framework_TestCase
 {
-
     protected function getFilter(array $methods = array())
     {
         $defaults = array_merge(
@@ -17,7 +16,6 @@ class AbstractCodeTransformTest extends \PHPUnit_framework_TestCase
             ->getMockForAbstractClass();
 
         if (in_array('transformCode', $methods)) {
-
             $filter
                 ->expects($this->once())
                 ->method('transformCode')

--- a/tests/VCR/ConfigurationTest.php
+++ b/tests/VCR/ConfigurationTest.php
@@ -22,7 +22,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(
             'VCR\VCRException',
             "Cassette path 'invalid_path' is not a directory. Please either "
-            . "create it or set a different cassette path using "
+            . 'create it or set a different cassette path using '
             . "\\VCR\\VCR::configure()->setCassettePath('directory')."
         );
         $this->config->setCassettePath('invalid_path');

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -277,7 +277,7 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(2, $callCount, 'Hook should have been called twice.');
         $this->assertEquals(
-            array("msg" => 1, "result" => 0, "handle" => $curlHandle2),
+            array('msg' => 1, 'result' => 0, 'handle' => $curlHandle2),
             $lastInfo,
             'When called the first time curl_multi_info_read should return last curl info.'
         );
@@ -320,8 +320,8 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $curlHandle = curl_init("http://example.com");
-        curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
+        $curlHandle = curl_init('http://example.com');
+        curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, 'DELETE');
         curl_reset($curlHandle);
         curl_exec($curlHandle);
 

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -266,8 +266,10 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         curl_multi_add_handle($curlMultiHandle, $curlHandle2);
 
         $mh = curl_multi_exec($curlMultiHandle);
-        $lastInfo = curl_multi_info_read($mh);
-        $afterLastInfo = curl_multi_info_read($mh);
+
+        $lastInfo       = curl_multi_info_read($mh);
+        $secondLastInfo = curl_multi_info_read($mh);
+        $afterLastInfo  = curl_multi_info_read($mh);
 
         curl_multi_remove_handle($curlMultiHandle, $curlHandle1);
         curl_multi_remove_handle($curlMultiHandle, $curlHandle2);
@@ -281,6 +283,13 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
             $lastInfo,
             'When called the first time curl_multi_info_read should return last curl info.'
         );
+
+        $this->assertEquals(
+            array('msg' => 1, 'result' => 0, 'handle' => $curlHandle1),
+            $secondLastInfo,
+            'When called the second time curl_multi_info_read should return second to last curl info.'
+        );
+
         $this->assertFalse($afterLastInfo, 'Multi info called the last time should return false.');
     }
 

--- a/tests/VCR/LibraryHooks/SoapHookTest.php
+++ b/tests/VCR/LibraryHooks/SoapHookTest.php
@@ -8,7 +8,6 @@ use VCR\Configuration;
 use VCR\CodeTransform\SoapCodeTransform;
 use VCR\Util\StreamProcessor;
 
-
 /**
  * Test if intercepting http/https using soap works.
  */

--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -119,7 +119,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function testStorePostFile()
     {
-
         $file = array(
             'fieldName'   => 'field_name',
             'contentType' => 'application/octet-stream',

--- a/tests/VCR/Storage/AbstractStorageTest.php
+++ b/tests/VCR/Storage/AbstractStorageTest.php
@@ -45,7 +45,7 @@ class TestStorage extends AbstractStorage
 
     public function next()
     {
-        list ($this->position, $this->current) = each ($this->recording);
+        list($this->position, $this->current) = each($this->recording);
 
         return $this->current;
     }

--- a/tests/VCR/Storage/JsonTest.php
+++ b/tests/VCR/Storage/JsonTest.php
@@ -103,7 +103,6 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         $this->jsonObject->storeRecording($stored);
 
         $this->assertJson(file_get_contents($this->filePath));
-
     }
 
     public function testStoreRecordingWhenBlankFileAlreadyExists()

--- a/tests/VCR/Storage/YamlTest.php
+++ b/tests/VCR/Storage/YamlTest.php
@@ -19,8 +19,8 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     public function testIterateOneObject()
     {
         $this->iterateAndTest(
-            "-". "\n"
-            . "    para1: val1",
+            '-' . "\n"
+            . '    para1: val1',
             array(
                 array('para1' => 'val1'),
             ),
@@ -31,10 +31,10 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     public function testIterateTwoObjects()
     {
         $this->iterateAndTest(
-            "-". "\n"
-            . "    para1: val1" . "\n"
-            . "-". "\n"
-            . "   para2: val2",
+            '-' . "\n"
+            . '    para1: val1' . "\n"
+            . '-' . "\n"
+            . '   para2: val2',
             array(
                 array('para1' => 'val1'),
                 array('para2' => 'val2'),
@@ -46,11 +46,11 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     public function testIterateFirstNestedObject()
     {
         $this->iterateAndTest(
-            "-". "\n"
-            . "    para1:" . "\n"
-            . "        para2: val2" . "\n"
-            . "-". "\n"
-            . "    para3: val3",
+            '-' . "\n"
+            . '    para1:' . "\n"
+            . '        para2: val2' . "\n"
+            . '-' . "\n"
+            . '    para3: val3',
             array(
                 array('para1' => array('para2' => 'val2')),
                 array('para3' => 'val3'),
@@ -62,11 +62,11 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     public function testIterateSecondNestedObject()
     {
         $this->iterateAndTest(
-            "-". "\n"
-            . "    para1: val1" . "\n"
-            . "-" . "\n"
-            . "    para2:" . "\n"
-            . "        para3: val3" . "\n",
+            '-' . "\n"
+            . '    para1: val1' . "\n"
+            . '-' . "\n"
+            . '    para2:' . "\n"
+            . '        para3: val3' . "\n",
             array(
                 array('para1' => 'val1'),
                 array('para2' => array('para3' => 'val3')),

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -127,6 +127,16 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $request->getHeaders());
     }
 
+    public function testSetCurlOptionOnRequestPostFieldsSetsPostMethod()
+    {
+        $request = new Request('GET', 'example.com');
+        $payload = json_encode(array('some' => 'test'));
+
+        CurlHelper::setCurlOptionOnRequest($request, CURLOPT_POSTFIELDS, $payload);
+
+        $this->assertEquals('POST', $request->getMethod());
+    }
+
     public function testSetCurlOptionReadFunctionToNull()
     {
         $request = new Request('POST', 'example.com');

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -134,7 +134,7 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
 
         CurlHelper::setCurlOptionOnRequest($request, CURLOPT_POSTFIELDS, $payload);
 
-        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('GET', $request->getMethod());
     }
 
     public function testSetCurlOptionReadFunctionToNull()

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -226,7 +226,7 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $expectedCh = curl_init();
         $expectedBody = 'example response';
         $curlOptions = array(
-            CURLOPT_WRITEFUNCTION => function($ch, $body) use ($test, $expectedCh, $expectedBody) {
+            CURLOPT_WRITEFUNCTION => function ($ch, $body) use ($test, $expectedCh, $expectedBody) {
                 $test->assertEquals($expectedCh, $ch);
                 $test->assertEquals($expectedBody, $body);
 

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -129,7 +129,7 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testSetCurlOptionReadFunctionToNull()
     {
-	    $request = new Request('POST', 'example.com');
+        $request = new Request('POST', 'example.com');
 
         CurlHelper::setCurlOptionOnRequest($request, CURLOPT_READFUNCTION, null, curl_init());
 
@@ -141,7 +141,8 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\VCR\VCRException', 'To set a CURLOPT_READFUNCTION, CURLOPT_INFILESIZE must be set.');
         $request = new Request('POST', 'example.com');
 
-        $callback = function ($curlHandle, $fileHandle, $size) {};
+        $callback = function ($curlHandle, $fileHandle, $size) {
+        };
 
         CurlHelper::setCurlOptionOnRequest($request, CURLOPT_READFUNCTION, $callback, curl_init());
         CurlHelper::validateCurlPOSTBody($request, curl_init());

--- a/tests/VCR/Util/StreamHelperTest.php
+++ b/tests/VCR/Util/StreamHelperTest.php
@@ -3,8 +3,8 @@ namespace VCR\Util;
 
 use VCR\Request;
 
-class StreamHelperTest extends \PHPUnit_Framework_TestCase {
-
+class StreamHelperTest extends \PHPUnit_Framework_TestCase
+{
     public function streamContexts()
     {
         $test = $this;
@@ -74,7 +74,8 @@ class StreamHelperTest extends \PHPUnit_Framework_TestCase {
      * @param $context
      * @param $testCallback
      */
-    public function testStreamHttpContext($context, $testCallback) {
+    public function testStreamHttpContext($context, $testCallback)
+    {
         $context = stream_context_create(array(
             'http' => $context
         ));

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -44,7 +44,7 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
     public function testUrlStatSuccessfully()
     {
         $test = $this;
-        set_error_handler(function($errno, $errstr, $errfile, $errline) use ($test) {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use ($test) {
             $test->fail('should not throw errors');
         });
 
@@ -79,7 +79,7 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
     public function testDirOpendirNotFound()
     {
         $test = $this;
-        set_error_handler(function($errno, $errstr, $errfile, $errline) use ($test) {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use ($test) {
             $test->assertContains('opendir(not_found', $errstr);
         });
 

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -6,6 +6,23 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
+     * test flock with file_put_contents
+     */
+    public function testFlockWithFilePutContents()
+    {
+        $processor = new StreamProcessor();
+        $processor->intercept();
+
+        $testData = 'test data';
+        $testFilePath = 'tests/fixtures/file_put_contents';
+        $res = file_put_contents($testFilePath, $testData, LOCK_EX);
+        unlink($testFilePath);
+
+        $processor->restore();
+        $this->assertEquals(strlen($testData), $res);
+    }
+
+    /**
      * @dataProvider streamOpenAppendFilterProvider
      * @param  boolean $expected
      * @param  boolean $shouldProcess

--- a/tests/VCR/VCRTest.php
+++ b/tests/VCR/VCRTest.php
@@ -10,10 +10,9 @@ use org\bovigo\vfs\vfsStream;
  */
 class VCRTest extends \PHPUnit_Framework_TestCase
 {
-
     public static function setupBeforeClass()
     {
-       VCR::configure()->setCassettePath('tests/fixtures') ;
+        VCR::configure()->setCassettePath('tests/fixtures') ;
     }
 
     public function testUseStaticCallsNotInitialized()
@@ -81,7 +80,7 @@ class VCRTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             'BadMethodCallException',
-            "Invalid http request. No cassette inserted. Please make sure to insert "
+            'Invalid http request. No cassette inserted. Please make sure to insert '
             . "a cassette in your unit test using VCR::insertCassette('name');"
         );
 
@@ -142,7 +141,6 @@ class VCRTest extends \PHPUnit_Framework_TestCase
         );
         VCR::eject();
         VCR::turnOff();
-
     }
 
     public function testShouldDispatchBeforeAfterHttpRequestAndBeforeRecordWhenCassetteHasNoResponse()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,10 @@
 <?php
 
-if (!file_exists(__DIR__ . "/../vendor/autoload.php")) {
+if (!file_exists(__DIR__ . '/../vendor/autoload.php')) {
     die(
-        "\n[ERROR] You need to run composer before running the test suite.\n".
-        "To do so run the following commands:\n".
-        "    curl -s http://getcomposer.org/installer | php\n".
+        "\n[ERROR] You need to run composer before running the test suite.\n" .
+        "To do so run the following commands:\n" .
+        "    curl -s http://getcomposer.org/installer | php\n" .
         "    php composer.phar install\n\n"
     );
 }

--- a/tests/integration/guzzle/3/ExampleHttpClient.php
+++ b/tests/integration/guzzle/3/ExampleHttpClient.php
@@ -44,5 +44,3 @@ class ExampleHttpClient
         return null;
     }
 }
-
-

--- a/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
+++ b/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
@@ -126,6 +126,6 @@ class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::TEST_POST_URL, $info['url'], "Value for key 'url' wrong.");
         $this->assertArrayHasKey('headers', $info, "Key 'headers' not found.");
         $this->assertTrue(is_array($info['headers']), 'Headers is not an array.');
-        $this->assertEquals(self::TEST_POST_BODY, $info['data'], "Correct request body was not sent.");
+        $this->assertEquals(self::TEST_POST_BODY, $info['data'], 'Correct request body was not sent.');
     }
 }

--- a/tests/integration/soap/test/VCR/Example/ExampleSoapClientTest.php
+++ b/tests/integration/soap/test/VCR/Example/ExampleSoapClientTest.php
@@ -18,17 +18,20 @@ class ExampleSoapClientTest extends \PHPUnit_Framework_TestCase
         \VCR\VCR::configure()->setCassettePath(vfsStream::url('testDir'));
     }
 
-    public function testCallDirectly() {
+    public function testCallDirectly()
+    {
         $actual = $this->callSoap();
         $this->assertInternalType('integer', $actual);
     }
 
-    public function testCallIntercepted() {
+    public function testCallIntercepted()
+    {
         $actual = $this->callSoapIntercepted();
         $this->assertInternalType('integer', $actual);
     }
 
-    public function testCallDirectlyEqualsIntercepted() {
+    public function testCallDirectlyEqualsIntercepted()
+    {
         $this->assertEquals($this->callSoap(), $this->callSoapIntercepted());
     }
 
@@ -47,5 +50,4 @@ class ExampleSoapClientTest extends \PHPUnit_Framework_TestCase
 
         return $result;
     }
-
 }


### PR DESCRIPTION
Changes:
- Updated vcr to be up to date with the master repo
- fixed bug where any curl request with CURLOPT_POSTFIELDS would be set to POST while it might not be the case (bug introduced in v1.3.2)
- fixed test that was introduced with the bug

Note: there are still some tests failing but they are related to the fact that the tests are making real SOAP connections to a broken website.

@rpalladino Can you review please?